### PR TITLE
Fixed a bug with jf <dirname> command.

### DIFF
--- a/hyperjump
+++ b/hyperjump
@@ -86,7 +86,7 @@ function jf() {
 	read -p "Forget It? [Y/N]: " -n 1 -e choice
 	case $choice in
 		"Y" | "y" )
-			tempfile=`mktemp -t "jumpdb"`
+			tempfile=`mktemp -t "XXXjumpdb"`
 			grep -v ":$wd$" $db > $tempfile
 			cat $tempfile > $db
 			rm $tempfile


### PR DESCRIPTION
Do to a not well formed tmp pattern name to pass to mktemp no one temp file will be generated and after jf <dirname> command ~/.hyperjumpdb will be replaced with an empty file.

Hyperjump is a great tool: carry on like that!!
