### PR TITLE
"jp" is "Jump Push":   think "jj" but with "pushd" instead of "cd"

### DIFF
--- a/hyperjump
+++ b/hyperjump
@@ -19,7 +19,7 @@ function _hyperjumpdatabase() {
 	echo "$db"
 }
 
-# Jump Remamber - Adds a jump to the database
+# Jump Remember - Adds a jump to the database
 function jr() {
 	local db=$(_hyperjumpdatabase)
 	local wd=$(pwd)
@@ -167,6 +167,70 @@ function jj() {
 	fi
 }
 
+# Jump Push to Nickname - Shows the Dialog Menu with all of the jumps in the db
+function jp() {
+	local db=$(_hyperjumpdatabase)
+	local foundDialog=0
+
+	# If no name on the prompt, than pop up the dialog, else use $1
+	if [[ -z "$1" ]]; then
+		if ! type dialog > /dev/null 2>&1; then
+			# Dialog Utility NOT found, so show alternative
+			echo Dialog utility NOT found. Install Dialog to get a nice menu of jump locations.
+			echo List of Saved Locations:
+			while read line
+			do
+				printf "    %-25s %s \n" "${line%:*}" "${line#*:}"
+			done < <(cat "$db")
+		else
+			local foundDialog=1
+			local list=""
+			while read line
+			do
+				line="'${line%:*}' '${line#*:}' "
+				list+=$line
+			done < <(cat "$db")
+
+			if [[ "$list" == "" ]]; then
+				echo The HyperJump Database is Empty. Bookmark a directory with the jr command to get started.
+			else
+				local cmd="dialog --menu 'Where do you want to jump to?' 22 76 16 $list"
+				local choice=$(eval "$cmd" 2>&1 >/dev/tty)
+				clear
+			fi
+		fi
+	else
+		local choice=$1
+	fi
+
+	# Check if the Jump is legit, and jump
+	if grep -q "^$choice:" "$db"; then
+		local line=$(grep "^$choice:" "$db" | head -n 1)
+		local target=${line#*:}
+		echo Navigating to "$choice" at "$target" and adding to dirs
+		pushd "$target"
+		# Run Additional Commands If Specified
+		local param
+		for param in ${@:2}
+		do
+			if [[ ! -z "$param" && "$param" != "" ]]; then
+				local cmd="$param ./"
+				echo Running \"$cmd\" inside $choice
+				eval "$cmd"
+			fi
+		done
+	else
+		if [[ -z "$choice" ]]; then
+			# Do not show the message if Dialog was not found
+			if [[ "$foundDialog" -eq 1 ]]; then
+				echo "Jump Cancelled"
+			fi
+		else
+			echo "Jump Nickname isn't in the Database"
+		fi
+	fi
+}
+
 # Autocomplete for Jump to Nickname
 _jj() {
 	local db=$(_hyperjumpdatabase)
@@ -198,5 +262,6 @@ if [[ -n "${ZSH_VERSION-}" ]]; then
 fi
 
 complete -F _jj jj
+complete -F _jj jp
 complete -F _jj jf
 complete -F _jr jr


### PR DESCRIPTION
jp is exactly the same as jj, but it uses "pushd" instead of "cd" to change directories to add to the dirs list.  

By using "pushd" instead of "cd" It adds the dirs stack and makes it easy to remember where one was jumping around to/from.

Also fixed typo in "jr" comment.